### PR TITLE
Set default environment to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# For Sinatra configuration, defaults to production. 
+# For local development, set this value to development
+APP_ENV=production
+
 TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 TWILIO_CALLER_ID=+1XXXYYYZZZZ
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ Voice "REQUEST URL" to be your ngrok URL plus `/voice`. For example:
 
 That's it!
 
+### Configure Development vs Production Settings
+
+By default, this application will run in production mode - stack traces will not be visible in the web browser. If you would like to run this application in development locally, change the `APP_ENV` variable in your `.env` file.
+
+`APP_ENV=development`
+
+For more about development vs production, visit [Sinatra's configuration page](http://sinatrarb.com/configuration.html).
+
 ### Docker
 
 If you have [Docker](https://www.docker.com/) already installed on your machine, you can use our `docker-compose.yml` to setup your project.

--- a/app.rb
+++ b/app.rb
@@ -9,6 +9,11 @@ require 'faker'
 # Load environment configuration
 Dotenv.load
 
+# Set the environment after dotenv loads
+# Default to production
+enviroment = (ENV['APP_ENV'] || ENV['RACK_ENV'] || :production).to_sym
+set :environment, enviroment
+
 # Render home page
 get '/' do
   File.read(File.join('public', 'index.html'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'rack/test'
 require 'rspec'
 
 ENV['RACK_ENV'] = 'test'
+ENV['APP_ENV'] = 'test'
 
 require File.expand_path('../app.rb', __dir__)
 


### PR DESCRIPTION
Set default environment to production.

Changes in the PR:

- Set `APP_ENV` to `production`
- Update README.
